### PR TITLE
By default authorize_local_message 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- By default authorize_local_message and show_local_message in messagesviewlet must be True in smartweb
+  [boulch]
 
 
 1.1.1 (2023-01-12)

--- a/src/imio/smartweb/policy/profiles/default/metadata.xml
+++ b/src/imio/smartweb/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1028</version>
+  <version>1029</version>
   <dependencies>
     <dependency>profile-plone.app.contenttypes:plone-content</dependency>
     <dependency>profile-plone.app.caching:default</dependency>

--- a/src/imio/smartweb/policy/profiles/default/registry/messagesviewlet.xml
+++ b/src/imio/smartweb/policy/profiles/default/registry/messagesviewlet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="imio.smartweb">
+
+  <records interface="collective.messagesviewlet.browser.controlpanel.IMessagesviewletSettings"
+           prefix="messagesviewlet">
+    <value key="authorize_local_message" i18n:translate="">True</value>
+    <value key="show_local_message" i18n:translate="">True</value>
+  </records>
+
+</registry>

--- a/src/imio/smartweb/policy/upgrades/configure.zcml
+++ b/src/imio/smartweb/policy/upgrades/configure.zcml
@@ -115,6 +115,14 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:registerProfile
+      name="upgrade_1028_to_1029"
+      title="Upgrade policy from 1028 to 1029"
+      directory="profiles/1028_to_1029"
+      description="Change collective.messagesviwlet control panel default values"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
   <genericsetup:upgradeStep
       title="Configure first official release"
       description="Install pas.plugins.imio and run needed profiles steps"
@@ -418,6 +426,17 @@
     <genericsetup:upgradeDepends
         title="Fix missing Plone icons (plone.staticresources)"
         import_profile="plone.staticresources:default"
+        import_steps="plone.app.registry"
+        />
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
+      source="1028"
+      destination="1029"
+      profile="imio.smartweb.policy:default">
+    <genericsetup:upgradeDepends
+        title="Change collective.messagesviwlet control panel default values"
+        import_profile="imio.smartweb.policy.upgrades:upgrade_1028_to_1029"
         import_steps="plone.app.registry"
         />
   </genericsetup:upgradeSteps>

--- a/src/imio/smartweb/policy/upgrades/profiles/1028_to_1029/registry/messagesviewlet.xml
+++ b/src/imio/smartweb/policy/upgrades/profiles/1028_to_1029/registry/messagesviewlet.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="imio.smartweb">
+
+  <records interface="collective.messagesviewlet.browser.controlpanel.IMessagesviewletSettings"
+           prefix="messagesviewlet">
+    <value key="authorize_local_message" i18n:translate="">True</value>
+    <value key="show_local_message" i18n:translate="">True</value>
+  </records>
+
+</registry>


### PR DESCRIPTION
and show_local_message in messagesviewlet must be True in smartweb.
This is a (validated) request from the smartweb team.

What do you think about this commit @laulaz ?