### PR TITLE
feat: upgrade step to clean TS api URL in registry to keep only base URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.18 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- CITI-15 : Add upgrade step to clean TS api URL in registry to keep only base URL.
+  [remdub]
 
 
 1.2.17 (2026-04-13)

--- a/src/imio/smartweb/policy/profiles/default/metadata.xml
+++ b/src/imio/smartweb/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1040</version>
+  <version>1041</version>
   <dependencies>
     <dependency>profile-plone.app.contenttypes:plone-content</dependency>
     <dependency>profile-plone.app.caching:default</dependency>

--- a/src/imio/smartweb/policy/tests/test_utils.py
+++ b/src/imio/smartweb/policy/tests/test_utils.py
@@ -3,8 +3,10 @@
 from imio.smartweb.policy.testing import (
     IMIO_SMARTWEB_POLICY_INTEGRATION_TESTING,
 )  # noqa: E501
+from imio.smartweb.policy.utils import get_ts_api_base_url
 from plone import api
 from plone.app.testing import setRoles, TEST_USER_ID
+from unittest.mock import patch
 
 import os
 import unittest
@@ -97,3 +99,35 @@ class TestUtils(unittest.TestCase):
         update_iam_folder_links(iam_folder, commit=False)
         link = api.content.get(path="/je-suis/commercant")
         assert link.remoteUrl == "https://www.kamoulox.be/commercant"
+
+
+class TestGetTsApiBaseUrl(unittest.TestCase):
+
+    layer = IMIO_SMARTWEB_POLICY_INTEGRATION_TESTING
+
+    @patch("imio.smartweb.core.utils.get_value_from_registry")
+    @patch("imio.smartweb.core.utils.is_valid_url")
+    @patch("imio.smartweb.policy.utils.urlparse")
+    def test_valid_url(self, mock_urlparse, mock_is_valid_url, mock_get_value):
+        mock_get_value.return_value = "https://kamoulox.be/formsdefs/something"
+        mock_is_valid_url.return_value = True
+        mock_urlparse.return_value.scheme = "https"
+        mock_urlparse.return_value.netloc = "kamoulox.be"
+        result = get_ts_api_base_url()
+        self.assertEqual(result, "https://kamoulox.be/")
+
+    @patch("imio.smartweb.core.utils.get_value_from_registry")
+    @patch("imio.smartweb.core.utils.is_valid_url")
+    def test_invalid_url(self, mock_is_valid_url, mock_get_value):
+        mock_get_value.return_value = "not-a-valid-url"
+        mock_is_valid_url.return_value = False
+        result = get_ts_api_base_url()
+        self.assertIsNone(result)
+
+    @patch("imio.smartweb.core.utils.get_value_from_registry")
+    @patch("imio.smartweb.core.utils.is_valid_url")
+    def test_empty_url(self, mock_is_valid_url, mock_get_value):
+        mock_get_value.return_value = ""
+        mock_is_valid_url.return_value = False
+        result = get_ts_api_base_url()
+        self.assertIsNone(result)

--- a/src/imio/smartweb/policy/upgrades/configure.zcml
+++ b/src/imio/smartweb/policy/upgrades/configure.zcml
@@ -185,7 +185,7 @@
       directory="profiles/1039_to_1040"
       description="Switch portal timezone from UTC to Europe/Brussels, available timezones to Europe/Brussels and first weekday to monday"
       provides="Products.GenericSetup.interfaces.EXTENSION"
-      />      
+      />
 
   <genericsetup:upgradeStep
       title="Configure first official release"
@@ -613,5 +613,14 @@
         import_profile="imio.smartweb.policy.upgrades:upgrade_1039_to_1040"
         />
   </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeStep
+    title="Clean TS api URL"
+    description="Clean TS api URL in registry to keep only base URL"
+    source="1040"
+    destination="1041"
+    handler=".upgrades.clean_ts_api_url"
+    profile="imio.smartweb.policy:default"
+    />
 
 </configure>

--- a/src/imio/smartweb/policy/upgrades/upgrades.py
+++ b/src/imio/smartweb/policy/upgrades/upgrades.py
@@ -71,3 +71,24 @@ def uninstall_plone_patternslib(context):
         return
     if installer.is_product_installed(product):
         installer.uninstall_product("plone.patternslib")
+
+def clean_ts_api_url(context):
+    from imio.smartweb.policy.utils import get_ts_api_base_url
+
+    url_before = api.portal.get_registry_record("smartweb.url_ts")
+    if url_before is None:
+        logger.info("TS api URL is empty in registry, nothing to clean.")
+        return
+    url_after = get_ts_api_base_url()
+    if url_before == url_after:
+        logger.info(
+            f"TS api URL {url_before} is already clean in registry, nothing to do."
+        )
+        return
+    if url_after is None:
+        logger.warning(
+            f"TS api URL {url_before} is not valid, cannot be cleaned. Please check the value in the registry."
+        )
+        return
+    api.portal.set_registry_record("smartweb.url_ts", url_after)
+    logger.info(f"TS api URL {url_before} cleaned in registry. New value: {url_after}.")

--- a/src/imio/smartweb/policy/upgrades/upgrades.py
+++ b/src/imio/smartweb/policy/upgrades/upgrades.py
@@ -72,11 +72,12 @@ def uninstall_plone_patternslib(context):
     if installer.is_product_installed(product):
         installer.uninstall_product("plone.patternslib")
 
+
 def clean_ts_api_url(context):
     from imio.smartweb.policy.utils import get_ts_api_base_url
 
     url_before = api.portal.get_registry_record("smartweb.url_ts")
-    if url_before is None:
+    if not url_before:
         logger.info("TS api URL is empty in registry, nothing to clean.")
         return
     url_after = get_ts_api_base_url()

--- a/src/imio/smartweb/policy/utils.py
+++ b/src/imio/smartweb/policy/utils.py
@@ -6,6 +6,7 @@ from plone import api
 from plone.i18n.normalizer import idnormalizer
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
+from urllib.parse import urlparse
 from z3c.form.interfaces import IFormLayer
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -284,3 +285,13 @@ def get_accessibility_html_content():
         <p>[[[Date à mentionner une fois que vous avez complété la partie relevant de votre responsabilité]]]</p>
         """
     return accessibility_html_content
+def get_ts_api_base_url() -> str | None:
+    """Get the base url of the ts api."""
+    from imio.smartweb.core.utils import get_value_from_registry
+    from imio.smartweb.core.utils import is_valid_url
+
+    url_ts = get_value_from_registry("smartweb.url_ts")
+    if is_valid_url(url_ts):
+        parsed_url = urlparse(url_ts)
+        return f"{parsed_url.scheme}://{parsed_url.netloc}/"
+    return None

--- a/src/imio/smartweb/policy/utils.py
+++ b/src/imio/smartweb/policy/utils.py
@@ -285,6 +285,8 @@ def get_accessibility_html_content():
         <p>[[[Date à mentionner une fois que vous avez complété la partie relevant de votre responsabilité]]]</p>
         """
     return accessibility_html_content
+
+
 def get_ts_api_base_url() -> str | None:
     """Get the base url of the ts api."""
     from imio.smartweb.core.utils import get_value_from_registry


### PR DESCRIPTION
CITI-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic upgrade to normalize the TS API URL in configuration so only the base URL is retained.

* **Tests**
  * Added tests covering TS API URL validation, normalization, and edge cases.

* **Chores**
  * Bumped policy profile version to 1041.

* **Documentation**
  * Updated changelog/unreleased entry to reflect the upgrade and removed the placeholder note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->