### PR TITLE
In smartweb, only Manager can delete MessagesFolder (from collective.…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.18 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- In smartweb, only Manager can delete MessagesFolder (from collective.messagesviewlet)
+  [boulch]
 
 
 1.2.17 (2026-04-13)

--- a/src/imio/smartweb/policy/profiles/default/metadata.xml
+++ b/src/imio/smartweb/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1040</version>
+  <version>1041</version>
   <dependencies>
     <dependency>profile-plone.app.contenttypes:plone-content</dependency>
     <dependency>profile-plone.app.caching:default</dependency>

--- a/src/imio/smartweb/policy/profiles/default/workflows.xml
+++ b/src/imio/smartweb/policy/profiles/default/workflows.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+  <object name="messagesconfig_workflow" meta_type="Workflow"/>
+  <bindings>
+    <type type_id="MessagesConfig">
+      <bound-workflow workflow_id="messagesconfig_workflow"/>
+    </type>
+  </bindings>
+</object>

--- a/src/imio/smartweb/policy/profiles/default/workflows/messagesconfig_workflow/definition.xml
+++ b/src/imio/smartweb/policy/profiles/default/workflows/messagesconfig_workflow/definition.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             i18n:domain="plone"
+             workflow_id="messagesconfig_workflow" title="Private messages-config folder Workflow"
+             state_variable="review_state" initial_state="private" manager_bypass="False">
+    <permission>Access contents information</permission>
+    <permission>Delete objects</permission>
+    <permission>Modify portal content</permission>
+    <permission>View</permission>
+    <state state_id="private" title="Private" i18n:attributes="title">
+        <description></description>
+        <permission-map name="Access contents information" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+            <permission-role>Reader</permission-role>
+            <permission-role>Contributor</permission-role>
+            <permission-role>Site Administrator</permission-role>
+        </permission-map>
+        <permission-map name="Delete objects" acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="Modify portal content" acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="View" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+            <permission-role>Reader</permission-role>
+            <permission-role>Contributor</permission-role>
+            <permission-role>Site Administrator</permission-role>
+        </permission-map>
+    </state>
+</dc-workflow>

--- a/src/imio/smartweb/policy/profiles/testing/workflows.xml
+++ b/src/imio/smartweb/policy/profiles/testing/workflows.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+  <object name="messagesconfig_workflow" meta_type="Workflow"/>
+  <bindings>
+    <type type_id="MessagesConfig">
+      <bound-workflow workflow_id="messagesconfig_workflow"/>
+    </type>
+  </bindings>
+</object>

--- a/src/imio/smartweb/policy/profiles/testing/workflows/messagesconfig_workflow/definition.xml
+++ b/src/imio/smartweb/policy/profiles/testing/workflows/messagesconfig_workflow/definition.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             i18n:domain="plone"
+             workflow_id="messagesconfig_workflow" title="Private messages-config folder Workflow"
+             state_variable="review_state" initial_state="private" manager_bypass="False">
+    <permission>Access contents information</permission>
+    <permission>Delete objects</permission>
+    <permission>Modify portal content</permission>
+    <permission>View</permission>
+    <state state_id="private" title="Private" i18n:attributes="title">
+        <description></description>
+        <permission-map name="Access contents information" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+            <permission-role>Reader</permission-role>
+            <permission-role>Contributor</permission-role>
+            <permission-role>Site Administrator</permission-role>
+        </permission-map>
+        <permission-map name="Delete objects" acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="Modify portal content" acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="View" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+            <permission-role>Reader</permission-role>
+            <permission-role>Contributor</permission-role>
+            <permission-role>Site Administrator</permission-role>
+        </permission-map>
+    </state>
+</dc-workflow>

--- a/src/imio/smartweb/policy/subscribers.py
+++ b/src/imio/smartweb/policy/subscribers.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from AccessControl.unauthorized import Unauthorized
+from plone import api
+
+
+def prevent_messages_config_delete(obj, event):
+    """Only Managers may remove the global messages configuration folder."""
+    if getattr(obj, "portal_type", None) != "MessagesConfig":
+        return
+
+    if "Manager" in api.user.get_roles(obj=obj):
+        return
+
+    raise Unauthorized("Only Managers can delete MessagesConfig objects.")

--- a/src/imio/smartweb/policy/subscribers.zcml
+++ b/src/imio/smartweb/policy/subscribers.zcml
@@ -11,4 +11,10 @@
       handler=".utils.update_iam_folder_links"
       />
 
+   <subscriber
+      for="*
+           OFS.interfaces.IObjectWillBeRemovedEvent"
+      handler=".subscribers.prevent_messages_config_delete"
+      />
+
 </configure>

--- a/src/imio/smartweb/policy/tests/test_messages_config_delete.py
+++ b/src/imio/smartweb/policy/tests/test_messages_config_delete.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from AccessControl.unauthorized import Unauthorized
+from imio.smartweb.policy.subscribers import prevent_messages_config_delete
+from imio.smartweb.policy.testing import IMIO_SMARTWEB_POLICY_INTEGRATION_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+
+import unittest
+
+
+class TestMessagesConfigDeleteProtection(unittest.TestCase):
+    layer = IMIO_SMARTWEB_POLICY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.messages_config = self.portal["messages-config"]
+
+    def test_messages_config_workflow_limits_delete_objects_to_manager(self):
+        workflow = self.portal.portal_workflow["messagesconfig_workflow"]
+        state = workflow.states["private"]
+
+        self.assertEqual(
+            state.permission_roles["Delete objects"],
+            ("Manager",),
+        )
+
+    def test_non_manager_cannot_delete_messages_config(self):
+        setRoles(self.portal, TEST_USER_ID, ["Site Administrator"])
+
+        with self.assertRaises(Unauthorized):
+            self.portal.manage_delObjects(["messages-config"])
+
+        self.assertIn("messages-config", self.portal.objectIds())
+
+    def test_manager_can_delete_messages_config(self):
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.portal.manage_delObjects(["messages-config"])
+
+        self.assertNotIn("messages-config", self.portal.objectIds())
+
+    def test_handler_blocks_non_manager(self):
+        setRoles(self.portal, TEST_USER_ID, ["Site Administrator"])
+
+        with self.assertRaises(Unauthorized):
+            prevent_messages_config_delete(self.messages_config, None)
+
+    def test_other_content_types_are_not_restricted(self):
+        setRoles(self.portal, TEST_USER_ID, ["Site Administrator"])
+
+        prevent_messages_config_delete(self.portal, None)

--- a/src/imio/smartweb/policy/upgrades/configure.zcml
+++ b/src/imio/smartweb/policy/upgrades/configure.zcml
@@ -187,6 +187,14 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />      
 
+  <genericsetup:registerProfile
+      name="upgrade_1040_to_1041"
+      title="Upgrade policy from 1040 to 1041"
+      directory="profiles/1040_to_1041"
+      description="Restrict MessagesConfig deletion to Managers"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
   <genericsetup:upgradeStep
       title="Configure first official release"
       description="Install pas.plugins.imio and run needed profiles steps"
@@ -611,6 +619,16 @@
     <genericsetup:upgradeDepends
         title="Switch portal timezone from UTC to Europe/Brussels, available timezones to Europe/Brussels and first weekday to monday"
         import_profile="imio.smartweb.policy.upgrades:upgrade_1039_to_1040"
+        />
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
+      source="1040"
+      destination="1041"
+      profile="imio.smartweb.policy:default">
+    <genericsetup:upgradeDepends
+        title="Restrict MessagesConfig deletion to Managers"
+        import_profile="imio.smartweb.policy.upgrades:upgrade_1040_to_1041"
         />
   </genericsetup:upgradeSteps>
 

--- a/src/imio/smartweb/policy/upgrades/profiles/1040_to_1041/workflows.xml
+++ b/src/imio/smartweb/policy/upgrades/profiles/1040_to_1041/workflows.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+  <object name="messagesconfig_workflow" meta_type="Workflow"/>
+  <bindings>
+    <type type_id="MessagesConfig">
+      <bound-workflow workflow_id="messagesconfig_workflow"/>
+    </type>
+  </bindings>
+</object>

--- a/src/imio/smartweb/policy/upgrades/profiles/1040_to_1041/workflows/messagesconfig_workflow/definition.xml
+++ b/src/imio/smartweb/policy/upgrades/profiles/1040_to_1041/workflows/messagesconfig_workflow/definition.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             i18n:domain="plone"
+             workflow_id="messagesconfig_workflow" title="Private messages-config folder Workflow"
+             state_variable="review_state" initial_state="private" manager_bypass="False">
+    <permission>Access contents information</permission>
+    <permission>Delete objects</permission>
+    <permission>Modify portal content</permission>
+    <permission>View</permission>
+    <state state_id="private" title="Private" i18n:attributes="title">
+        <description></description>
+        <permission-map name="Access contents information" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+            <permission-role>Reader</permission-role>
+            <permission-role>Contributor</permission-role>
+            <permission-role>Site Administrator</permission-role>
+        </permission-map>
+        <permission-map name="Delete objects" acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="Modify portal content" acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="View" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+            <permission-role>Reader</permission-role>
+            <permission-role>Contributor</permission-role>
+            <permission-role>Site Administrator</permission-role>
+        </permission-map>
+    </state>
+</dc-workflow>


### PR DESCRIPTION
…messagesviewlet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted deletion of messages configuration folders to Manager role only, enhancing access control and preventing unauthorized removal of critical message management resources.

* **Chores**
  * Updated system version to 1041 with automated upgrade path support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->